### PR TITLE
Make plot from logo.R reproducible

### DIFF
--- a/_rmd/logo.R
+++ b/_rmd/logo.R
@@ -73,7 +73,7 @@ plot(gl.laea, add = TRUE, col = grey(.8))
 
 library(trajectories)
 data(storms)
-plot(as(spTransform(storms[1][1:12], laea), "SpatialLines"), add = TRUE, 
+plot(spTransform(as(storms[1][1:12], "SpatialLines"), laea), add = TRUE, 
 	col = brewer.pal(12, "Paired"), lwd = 3)
 box()
 


### PR DESCRIPTION
At least on my machine, the code runs up until the call to `spTransform(storms[1][1:12], laea)`, at which point I  get the error message:

    Error in (function (classes, fdef, mtable)  : 
      unable to find an inherited method for function ‘spTransform’ for signature ‘"Tracks", "CRS"’

First converting the `"Tracks"` object to a `"SpatialLines"` object and *then* applying `spTranform()` fixes the error (though it may be that `spTransform()` is *intended* to work on `"Tracks"` objects, and I'm just uncovering a regression of some type).