### PR TITLE
bechmark scripts works on sf 0.7.3

### DIFF
--- a/_posts/2017-06-22-spatial-index.markdown
+++ b/_posts/2017-06-22-spatial-index.markdown
@@ -135,7 +135,7 @@ bounding boxes before the expensive pairwise comparison takes place.
 
 Script used
 -----------
-The followinig script was used to create the benchmark plots. It no longer works; in the version where it worked, `prepared = FALSE` would take a branch where no trees were built, this is no longer the case.
+The followinig script can be used to create the benchmark plots. `prepared = FALSE` would take a branch where no trees were built.
 
      library(sf)
      sizes = c(10, 20, 50, 100, 160, 200)


### PR DESCRIPTION
I ran benchmark scripts on sf 0.7.3. And it worked well. 

I would be helpful to update blog so that everybody could know 'prepare=FALSE' works. 