### PR TITLE
2020-03-17-wkt.markdown: fix URL of WKT2

### DIFF
--- a/_posts/2020-03-17-wkt.markdown
+++ b/_posts/2020-03-17-wkt.markdown
@@ -41,7 +41,7 @@ gdalbarn
 Motivated by the need for higher precision handling of coordinate
 transformations and the wish to support for a better description of
 coordinate reference systems
-([WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html)), a
+([WKT2](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html)), a
 succesful [fundraising](https://gdalbarn.com) helped the implementation
 of a large number of changes in GDAL and PROJ, most notably:
 


### PR DESCRIPTION
The link led to version 1, not version 2. Also https://gdalbarn.com seems to be affected BTW.